### PR TITLE
fix compile on debian buster

### DIFF
--- a/src/amx_curl_class.h
+++ b/src/amx_curl_class.h
@@ -1,6 +1,7 @@
 #ifndef _AMX_CURL_CLASS_H_
 #define _AMX_CURL_CLASS_H_
 
+#include <functional>
 #include "curl_class.h"
 #include "amx_curl_callback_class.h"
 

--- a/src/curl_multi_class.cc
+++ b/src/curl_multi_class.cc
@@ -1,4 +1,5 @@
 #include "curl_multi_class.h"
+#include <functional>
 
 #ifdef AMXXCURL_DEBUG_LOG_ENABLE
 #include <cstdio>


### PR DESCRIPTION
tried to compile on current debian buster with latest [premake5](https://github.com/premake/premake-core/releases/tag/v5.0.0-alpha15), but failed with:

```
user@host:~/work/AmxxCurl/build/gmake$ make                                                                                                                      
==== Building AmxxCurl (releasedll) ====                                                                                                                    
Creating obj/ReleaseDLL                                                                                                                                         
amx_curl_callback_class.cc                                                                                                                                      
asio_poller.cc                                                                                                                                                  
callbacks.cc                                                                                                                                                    
In file included from ../../src/amx_curl_manager_class.h:13,                                                                                                    
                 from ../../src/amx_curl_controller_class.h:4,                                                                                                  
                 from ../../src/callbacks.cc:3:                                                                                                              
../../src/amx_curl_class.h: In member function ‘void AmxCurl::Perform(const char*, int, cell*, int)’:                                                           
../../src/amx_curl_class.h:45:56: error: ‘bind’ is not a member of ‘std’                                                                                        
         CurlMulti::CurlPerformComplete callback = std::bind(&AmxCurl::OnPerformComplete, this, std::placeholders::_1);                                         
                                                        ^~~~                                                                                                    
../../src/amx_curl_class.h:45:56: note: ‘std::bind’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?                             
../../src/amx_curl_class.h:6:1:                                                                                                                                  
+#include <functional>                                                                                                                                      
                                                                                                                                                                 
../../src/amx_curl_class.h:45:56:                                                                                                                               
         CurlMulti::CurlPerformComplete callback = std::bind(&AmxCurl::OnPerformComplete, this, std::placeholders::_1);                                         
                                                        ^~~~                                                                                                     
../../src/amx_curl_class.h:45:101: error: ‘std::placeholders’ has not been declared                                                                             
         CurlMulti::CurlPerformComplete callback = std::bind(&AmxCurl::OnPerformComplete, this, std::placeholders::_1);                                          
                                                                                                     ^~~~~~~~~~~~                                             
make[1]: *** [AmxxCurl.make:141: obj/ReleaseDLL/callbacks.o] Fehler 1                                                                                            
make: *** [Makefile:27: AmxxCurl] Fehler 2                                
```
same happend with `curl_multi_class.cc`, so simply added `#include <functional>` to both.
module loads fine on amxx 1.10.5417.